### PR TITLE
backporting: AWS Termination handling fix for 1.16 release

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/auth/signers/signer_ecs_ram_role.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/auth/signers/signer_ecs_ram_role.go
@@ -123,7 +123,7 @@ func (signer *EcsRamRoleSigner) refreshApi(request *requests.CommonRequest) (res
 
 func (signer *EcsRamRoleSigner) refreshCredential(response *responses.CommonResponse) (err error) {
 	if response.GetHttpStatus() != http.StatusOK {
-		fmt.Println("refresh Ecs sts token err, httpStatus: " + string(response.GetHttpStatus()) + ", message = " + response.GetHttpContentString())
+		fmt.Println("refresh Ecs sts token err, httpStatus: " + fmt.Sprintf("%d", response.GetHttpStatus()) + ", message = " + response.GetHttpContentString())
 		return
 	}
 	var data interface{}

--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling.go
@@ -81,7 +81,6 @@ func (m *autoScalingWrapper) getAutoscalingGroupsByNames(names []string) ([]*aut
 			AutoScalingGroupNames: aws.StringSlice(names[i:end]),
 			MaxRecords:            aws.Int64(maxRecordsReturnedByAPI),
 		}
-		fmt.Println("CALLING DESCRIBE AUTOSCALING GROUPS", aws.StringSlice(names[i:end]))
 		if err := m.DescribeAutoScalingGroupsPages(input, func(output *autoscaling.DescribeAutoScalingGroupsOutput, _ bool) bool {
 			asgs = append(asgs, output.AutoScalingGroups...)
 			// We return true while we want to be called with the next page of

--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling.go
@@ -81,6 +81,7 @@ func (m *autoScalingWrapper) getAutoscalingGroupsByNames(names []string) ([]*aut
 			AutoScalingGroupNames: aws.StringSlice(names[i:end]),
 			MaxRecords:            aws.Int64(maxRecordsReturnedByAPI),
 		}
+		fmt.Println("CALLING DESCRIBE AUTOSCALING GROUPS", aws.StringSlice(names[i:end]))
 		if err := m.DescribeAutoScalingGroupsPages(input, func(output *autoscaling.DescribeAutoScalingGroupsOutput, _ bool) bool {
 			asgs = append(asgs, output.AutoScalingGroups...)
 			// We return true while we want to be called with the next page of

--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -37,14 +37,14 @@ const (
 )
 
 type asgCache struct {
-	registeredAsgs    []*asg
-	asgToInstances    map[AwsRef][]AwsInstanceRef
-	instanceToAsg     map[AwsInstanceRef]*asg
-	instanceLifecycle map[AwsInstanceRef]*string
+	registeredAsgs []*asg
+	asgToInstances map[AwsRef][]AwsInstanceRef
+	instanceToAsg  map[AwsInstanceRef]*asg
+	mutex          sync.Mutex
+	service        autoScalingWrapper
+	interrupt      chan struct{}
 
-	mutex     sync.Mutex
-	service   autoScalingWrapper
-	interrupt chan struct{}
+	instanceLifecycle map[AwsInstanceRef]*string
 
 	asgAutoDiscoverySpecs []cloudprovider.ASGAutoDiscoveryConfig
 	explicitlyConfigured  map[AwsRef]bool

--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -37,12 +37,14 @@ const (
 )
 
 type asgCache struct {
-	registeredAsgs []*asg
-	asgToInstances map[AwsRef][]AwsInstanceRef
-	instanceToAsg  map[AwsInstanceRef]*asg
-	mutex          sync.Mutex
-	service        autoScalingWrapper
-	interrupt      chan struct{}
+	registeredAsgs    []*asg
+	asgToInstances    map[AwsRef][]AwsInstanceRef
+	instanceToAsg     map[AwsInstanceRef]*asg
+	instanceLifecycle map[AwsInstanceRef]*string
+
+	mutex     sync.Mutex
+	service   autoScalingWrapper
+	interrupt chan struct{}
 
 	asgAutoDiscoverySpecs []cloudprovider.ASGAutoDiscoveryConfig
 	explicitlyConfigured  map[AwsRef]bool
@@ -78,6 +80,7 @@ func newASGCache(service autoScalingWrapper, explicitSpecs []string, autoDiscove
 		service:               service,
 		asgToInstances:        make(map[AwsRef][]AwsInstanceRef),
 		instanceToAsg:         make(map[AwsInstanceRef]*asg),
+		instanceLifecycle:     make(map[AwsInstanceRef]*string),
 		interrupt:             make(chan struct{}),
 		asgAutoDiscoverySpecs: autoDiscoverySpecs,
 		explicitlyConfigured:  make(map[AwsRef]bool),
@@ -88,6 +91,14 @@ func newASGCache(service autoScalingWrapper, explicitSpecs []string, autoDiscove
 	}
 
 	return registry, nil
+}
+
+func (m *asgCache) findInstanceLifecycle(ref AwsInstanceRef) (*string, error) {
+	if lifecycle, found := m.instanceLifecycle[ref]; found {
+		return lifecycle, nil
+	}
+
+	return nil, fmt.Errorf("could not find instance %v", ref)
 }
 
 // Fetch explicitly configured ASGs. These ASGs should never be unregistered
@@ -268,6 +279,23 @@ func (m *asgCache) DeleteInstances(instances []*AwsInstanceRef) error {
 				"of deleting instance", instance.Name)
 			m.decreaseAsgSizeByOneNoLock(commonAsg)
 		} else {
+			// check if the instance is already terminating - if it is, don't bother terminating again
+			// as doing so causes unnecessary API calls and can cause the curSize cached value to decrement
+			// unnecessarily.
+			lifecycle, err := m.findInstanceLifecycle(*instance)
+			if err != nil {
+				return err
+			}
+
+			if lifecycle != nil &&
+				*lifecycle == autoscaling.LifecycleStateTerminated ||
+				*lifecycle == autoscaling.LifecycleStateTerminating ||
+				*lifecycle == autoscaling.LifecycleStateTerminatingWait ||
+				*lifecycle == autoscaling.LifecycleStateTerminatingProceed {
+				klog.V(2).Infof("instance %s is already terminating in state %s, will skip instead", instance.Name, *lifecycle)
+				continue
+			}
+
 			params := &autoscaling.TerminateInstanceInAutoScalingGroupInput{
 				InstanceId:                     aws.String(instance.Name),
 				ShouldDecrementDesiredCapacity: aws.Bool(true),
@@ -277,10 +305,9 @@ func (m *asgCache) DeleteInstances(instances []*AwsInstanceRef) error {
 				return err
 			}
 			klog.V(4).Infof(*resp.Activity.Description)
+			// keep our cache in sync with current size, only on success
+			commonAsg.curSize--
 		}
-
-		// Proactively decrement the size so autoscaler makes better decisions
-		commonAsg.curSize--
 	}
 	return nil
 }
@@ -343,6 +370,7 @@ func (m *asgCache) regenerate() error {
 
 	newInstanceToAsgCache := make(map[AwsInstanceRef]*asg)
 	newAsgToInstancesCache := make(map[AwsRef][]AwsInstanceRef)
+	newInstanceLifecycleMap := make(map[AwsInstanceRef]*string)
 
 	// Build list of knowns ASG names
 	refreshNames, err := m.buildAsgNames()
@@ -379,6 +407,7 @@ func (m *asgCache) regenerate() error {
 			ref := m.buildInstanceRefFromAWS(instance)
 			newInstanceToAsgCache[ref] = asg
 			newAsgToInstancesCache[asg.AwsRef][i] = ref
+			newInstanceLifecycleMap[ref] = instance.LifecycleState
 		}
 	}
 
@@ -391,6 +420,7 @@ func (m *asgCache) regenerate() error {
 
 	m.asgToInstances = newAsgToInstancesCache
 	m.instanceToAsg = newInstanceToAsgCache
+	m.instanceLifecycle = newInstanceLifecycleMap
 	return nil
 }
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -529,7 +529,7 @@ func TestDeleteNodesTerminatedInstances(t *testing.T) {
 
 	initialSize, err := asgs[0].TargetSize()
 	assert.NoError(t, err)
-	assert.Equal(t, expectedInstancesCount, initialSize)
+	assert.Equal(t, 2, initialSize)
 
 	// try deleting a node, but all of them are already in a
 	// Terminated state, so we should see no calls to Terminate.
@@ -576,8 +576,6 @@ func TestDeleteNodesTerminatingInstances(t *testing.T) {
 	).Run(func(args mock.Arguments) {
 		fn := args.Get(1).(func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool)
 		fn(testSetASGInstanceLifecycle(testNamedDescribeAutoScalingGroupsOutput("test-asg", expectedInstancesCount, "test-instance-id", "second-test-instance-id"), autoscaling.LifecycleStateTerminatingWait), false)
-		// we expect the instance count to be 1 after the call to DeleteNodes
-		expectedInstancesCount = 1
 	}).Return(nil)
 
 	provider.Refresh()

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -113,6 +113,7 @@ func testNamedDescribeAutoScalingGroupsOutput(groupName string, desiredCap int64
 		instances = append(instances, &autoscaling.Instance{
 			InstanceId:       aws.String(id),
 			AvailabilityZone: aws.String("us-east-1a"),
+			LifecycleState:   aws.String(autoscaling.LifecycleStateInService),
 		})
 	}
 	return &autoscaling.DescribeAutoScalingGroupsOutput{
@@ -126,6 +127,15 @@ func testNamedDescribeAutoScalingGroupsOutput(groupName string, desiredCap int64
 			},
 		},
 	}
+}
+
+func testSetASGInstanceLifecycle(asg *autoscaling.DescribeAutoScalingGroupsOutput, lifecycleState string) *autoscaling.DescribeAutoScalingGroupsOutput {
+	for _, asg := range asg.AutoScalingGroups {
+		for _, instance := range asg.Instances {
+			instance.LifecycleState = aws.String(lifecycleState)
+		}
+	}
+	return asg
 }
 
 func testProvider(t *testing.T, m *AwsManager) *awsCloudProvider {
@@ -488,4 +498,100 @@ func TestCleanup(t *testing.T) {
 	provider := testProvider(t, testAwsManager)
 	err := provider.Cleanup()
 	assert.NoError(t, err)
+}
+
+func TestDeleteNodesTerminatingInstances(t *testing.T) {
+	a := &autoScalingMock{}
+	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))
+	asgs := provider.NodeGroups()
+
+	a.On("TerminateInstanceInAutoScalingGroup", &autoscaling.TerminateInstanceInAutoScalingGroupInput{
+		InstanceId:                     aws.String("test-instance-id"),
+		ShouldDecrementDesiredCapacity: aws.Bool(true),
+	}).Return(&autoscaling.TerminateInstanceInAutoScalingGroupOutput{
+		Activity: &autoscaling.Activity{Description: aws.String("Deleted instance")},
+	})
+
+	// Look up the current number of instances...
+	var expectedInstancesCount int64 = 2
+	a.On("DescribeAutoScalingGroupsPages",
+		&autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: aws.StringSlice([]string{"test-asg"}),
+			MaxRecords:            aws.Int64(maxRecordsReturnedByAPI),
+		},
+		mock.AnythingOfType("func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool"),
+	).Run(func(args mock.Arguments) {
+		fn := args.Get(1).(func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool)
+		fn(testSetASGInstanceLifecycle(testNamedDescribeAutoScalingGroupsOutput("test-asg", expectedInstancesCount, "test-instance-id", "second-test-instance-id"), autoscaling.LifecycleStateTerminatingWait), false)
+		// we expect the instance count to be 1 after the call to DeleteNodes
+		expectedInstancesCount = 1
+	}).Return(nil)
+
+	provider.Refresh()
+
+	initialSize, err := asgs[0].TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, initialSize)
+
+	node := &apiv1.Node{
+		Spec: apiv1.NodeSpec{
+			ProviderID: "aws:///us-east-1a/test-instance-id",
+		},
+	}
+	err = asgs[0].DeleteNodes([]*apiv1.Node{node})
+	assert.NoError(t, err)
+	a.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", 0) // instances which are terminating don't need to be terminated again
+	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 1)
+
+	newSize, err := asgs[0].TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, newSize)
+}
+
+func TestDeleteNodesTerminatedInstances(t *testing.T) {
+	a := &autoScalingMock{}
+	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))
+	asgs := provider.NodeGroups()
+
+	a.On("TerminateInstanceInAutoScalingGroup", &autoscaling.TerminateInstanceInAutoScalingGroupInput{
+		InstanceId:                     aws.String("test-instance-id"),
+		ShouldDecrementDesiredCapacity: aws.Bool(true),
+	}).Return(&autoscaling.TerminateInstanceInAutoScalingGroupOutput{
+		Activity: &autoscaling.Activity{Description: aws.String("Deleted instance")},
+	})
+
+	// Look up the current number of instances...
+	var expectedInstancesCount int64 = 2
+	a.On("DescribeAutoScalingGroupsPages",
+		&autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: aws.StringSlice([]string{"test-asg"}),
+			MaxRecords:            aws.Int64(maxRecordsReturnedByAPI),
+		},
+		mock.AnythingOfType("func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool"),
+	).Run(func(args mock.Arguments) {
+		fn := args.Get(1).(func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool)
+		fn(testSetASGInstanceLifecycle(testNamedDescribeAutoScalingGroupsOutput("test-asg", expectedInstancesCount, "test-instance-id", "second-test-instance-id"), autoscaling.LifecycleStateTerminated), false)
+		// we expect the instance count to be 1 after the call to DeleteNodes
+		expectedInstancesCount = 1
+	}).Return(nil)
+
+	provider.Refresh()
+
+	initialSize, err := asgs[0].TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, initialSize)
+
+	node := &apiv1.Node{
+		Spec: apiv1.NodeSpec{
+			ProviderID: "aws:///us-east-1a/test-instance-id",
+		},
+	}
+	err = asgs[0].DeleteNodes([]*apiv1.Node{node})
+	assert.NoError(t, err)
+	a.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", 0) // instances which are terminating don't need to be terminated again
+	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 1)
+
+	newSize, err := asgs[0].TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, newSize)
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -543,7 +543,7 @@ func TestDeleteNodesTerminatedInstances(t *testing.T) {
 	// we expect no calls to TerminateInstanceInAutoScalingGroup,
 	// because the Node we tried to Delete was already terminating.
 	a.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", 0)
-	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 1)
+	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 2) // this version of autoscaler calls refresh after a delete.
 
 	newSize, err := asgs[0].TargetSize()
 	assert.NoError(t, err)
@@ -579,12 +579,10 @@ func TestDeleteNodesTerminatingInstances(t *testing.T) {
 	}).Return(nil)
 
 	provider.Refresh()
-	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 1)
 
 	initialSize, err := asgs[0].TargetSize()
 	assert.NoError(t, err)
 	assert.Equal(t, 2, initialSize)
-	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 1)
 
 	node := &apiv1.Node{
 		Spec: apiv1.NodeSpec{
@@ -594,7 +592,7 @@ func TestDeleteNodesTerminatingInstances(t *testing.T) {
 	err = asgs[0].DeleteNodes([]*apiv1.Node{node})
 	assert.NoError(t, err)
 	a.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", 0) // instances which are terminating don't need to be terminated again
-	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 1)
+	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 2)      // this version of autoscaler calls refresh after a delete.
 
 	newSize, err := asgs[0].TargetSize()
 	assert.NoError(t, err)

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -501,7 +501,7 @@ func TestCleanup(t *testing.T) {
 }
 
 func TestDeleteNodesTerminatingInstances(t *testing.T) {
-	a := &autoScalingMock{}
+	a := &AutoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))
 	asgs := provider.NodeGroups()
 
@@ -549,7 +549,7 @@ func TestDeleteNodesTerminatingInstances(t *testing.T) {
 }
 
 func TestDeleteNodesTerminatedInstances(t *testing.T) {
-	a := &autoScalingMock{}
+	a := &AutoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))
 	asgs := provider.NodeGroups()
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -501,7 +501,7 @@ func TestCleanup(t *testing.T) {
 }
 
 func TestDeleteNodesTerminatedInstances(t *testing.T) {
-	a := &autoScalingMock{}
+	a := &AutoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, []string{"1:5:test-asg"}))
 	asgs := provider.NodeGroups()
 
@@ -553,7 +553,7 @@ func TestDeleteNodesTerminatedInstances(t *testing.T) {
 	assert.Equal(t, initialSize, newSize)
 }
 
-func TestDeleteNodesTerminatedInstances(t *testing.T) {
+func TestDeleteNodesTerminatingInstances(t *testing.T) {
 	a := &AutoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, []string{"1:5:test-asg"}))
 	asgs := provider.NodeGroups()
@@ -575,7 +575,7 @@ func TestDeleteNodesTerminatedInstances(t *testing.T) {
 		mock.AnythingOfType("func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool"),
 	).Run(func(args mock.Arguments) {
 		fn := args.Get(1).(func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool)
-		fn(testSetASGInstanceLifecycle(testNamedDescribeAutoScalingGroupsOutput("test-asg", expectedInstancesCount, "test-instance-id", "second-test-instance-id"), autoscaling.LifecycleStateTerminated), false)
+		fn(testSetASGInstanceLifecycle(testNamedDescribeAutoScalingGroupsOutput("test-asg", expectedInstancesCount, "test-instance-id", "second-test-instance-id"), autoscaling.LifecycleStateTerminatingWait), false)
 		// we expect the instance count to be 1 after the call to DeleteNodes
 		expectedInstancesCount = 1
 	}).Return(nil)

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -579,10 +579,12 @@ func TestDeleteNodesTerminatingInstances(t *testing.T) {
 	}).Return(nil)
 
 	provider.Refresh()
+	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 1)
 
 	initialSize, err := asgs[0].TargetSize()
 	assert.NoError(t, err)
 	assert.Equal(t, 2, initialSize)
+	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 1)
 
 	node := &apiv1.Node{
 		Spec: apiv1.NodeSpec{

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -500,9 +500,9 @@ func TestCleanup(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestDeleteNodesTerminatingInstances(t *testing.T) {
-	a := &AutoScalingMock{}
-	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))
+func TestDeleteNodesTerminatedInstances(t *testing.T) {
+	a := &autoScalingMock{}
+	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, []string{"1:5:test-asg"}))
 	asgs := provider.NodeGroups()
 
 	a.On("TerminateInstanceInAutoScalingGroup", &autoscaling.TerminateInstanceInAutoScalingGroupInput{
@@ -512,8 +512,7 @@ func TestDeleteNodesTerminatingInstances(t *testing.T) {
 		Activity: &autoscaling.Activity{Description: aws.String("Deleted instance")},
 	})
 
-	// Look up the current number of instances...
-	var expectedInstancesCount int64 = 2
+	expectedInstancesCount := 2
 	a.On("DescribeAutoScalingGroupsPages",
 		&autoscaling.DescribeAutoScalingGroupsInput{
 			AutoScalingGroupNames: aws.StringSlice([]string{"test-asg"}),
@@ -522,17 +521,18 @@ func TestDeleteNodesTerminatingInstances(t *testing.T) {
 		mock.AnythingOfType("func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool"),
 	).Run(func(args mock.Arguments) {
 		fn := args.Get(1).(func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool)
-		fn(testSetASGInstanceLifecycle(testNamedDescribeAutoScalingGroupsOutput("test-asg", expectedInstancesCount, "test-instance-id", "second-test-instance-id"), autoscaling.LifecycleStateTerminatingWait), false)
-		// we expect the instance count to be 1 after the call to DeleteNodes
-		expectedInstancesCount = 1
+		fn(testSetASGInstanceLifecycle(testNamedDescribeAutoScalingGroupsOutput("test-asg", int64(expectedInstancesCount), "test-instance-id", "second-test-instance-id"), autoscaling.LifecycleStateTerminated), false)
 	}).Return(nil)
 
+	// load ASG state into cache
 	provider.Refresh()
 
 	initialSize, err := asgs[0].TargetSize()
 	assert.NoError(t, err)
-	assert.Equal(t, 2, initialSize)
+	assert.Equal(t, expectedInstancesCount, initialSize)
 
+	// try deleting a node, but all of them are already in a
+	// Terminated state, so we should see no calls to Terminate.
 	node := &apiv1.Node{
 		Spec: apiv1.NodeSpec{
 			ProviderID: "aws:///us-east-1a/test-instance-id",
@@ -540,17 +540,22 @@ func TestDeleteNodesTerminatingInstances(t *testing.T) {
 	}
 	err = asgs[0].DeleteNodes([]*apiv1.Node{node})
 	assert.NoError(t, err)
-	a.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", 0) // instances which are terminating don't need to be terminated again
+	// we expect no calls to TerminateInstanceInAutoScalingGroup,
+	// because the Node we tried to Delete was already terminating.
+	a.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", 0)
 	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 1)
 
 	newSize, err := asgs[0].TargetSize()
 	assert.NoError(t, err)
-	assert.Equal(t, 2, newSize)
+	// we expect TargetSize to stay the same, even though there are
+	// two instances in Terminated state - TargetSize was already
+	// adjusted for them in a previous loop.
+	assert.Equal(t, initialSize, newSize)
 }
 
 func TestDeleteNodesTerminatedInstances(t *testing.T) {
 	a := &AutoScalingMock{}
-	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))
+	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, []string{"1:5:test-asg"}))
 	asgs := provider.NodeGroups()
 
 	a.On("TerminateInstanceInAutoScalingGroup", &autoscaling.TerminateInstanceInAutoScalingGroupInput{


### PR DESCRIPTION
bring up AWS patch for termination
Brings in:

https://github.com/kubernetes/autoscaler/pull/5411
https://github.com/kubernetes/autoscaler/pull/6166

But the code is so different I manually brought it up to speed.

Also, I added a patch to make tests pass in the latest version of Go.